### PR TITLE
Update Gemini Flash option to gemini-3.1-flash-lite-preview

### DIFF
--- a/llm_insights/views.py
+++ b/llm_insights/views.py
@@ -93,7 +93,7 @@ class InsightsView(View):
         profile = getattr(user, "profile", None)
         provider_models = {
             "gemini": [
-                ("gemini-3-flash-preview", "Gemini 3 Flash"),
+                ("gemini-3.1-flash-lite-preview", "Gemini 3.1 Flash"),
                 ("gemini-3.1-pro-preview", "Gemini 3.1 Pro Preview"),
             ]
         }


### PR DESCRIPTION
### Motivation
- Align the available Gemini model options with the updated upstream model naming by replacing the older "3 Flash" entry with the new 3.1 Flash Lite preview identifier.

### Description
- Replaced the Gemini choice in `InsightsView._provider_models` in `llm_insights/views.py` from `("gemini-3-flash-preview", "Gemini 3 Flash")` to `("gemini-3.1-flash-lite-preview", "Gemini 3.1 Flash")`.

### Testing
- Ran `python -m compileall llm_insights/views.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dcb7a5335c83258e77344a25a64865)