### PR TITLE
Improve live timer sync on home and timers pages

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -1548,6 +1548,9 @@ def list_sessions(request):
 @permission_classes([IsAuthenticated])
 def list_active_sessions(request):
     sessions = Sessions.objects.filter(is_active=True, user=request.user)
+    sessions = filter_by_active_context(
+        sessions, request, override_context_id=request.query_params.get("context")
+    )
     serializer = SessionSerializer(sessions, many=True)
     return Response(serializer.data)
 

--- a/core/static/core/js/dynamic_timers.js
+++ b/core/static/core/js/dynamic_timers.js
@@ -1,7 +1,9 @@
 $(document).ready(function() {
+    const ACTIVE_TIMERS_SELECTOR = '#active-timers';
+    const TIMER_CARD_SELECTOR = `${ACTIVE_TIMERS_SELECTOR} .card[id^="timer-"]`;
 
     function updateDurations() {
-        $('.card').each(function() {
+        $(TIMER_CARD_SELECTOR).each(function() {
             let startTime = new Date($(this).data('start-time'));
             let now = new Date();
             let elapsedTime = now - startTime;
@@ -38,9 +40,43 @@ $(document).ready(function() {
         return build_time;
     }
 
+    function getLocalTimerIds() {
+        return $(TIMER_CARD_SELECTOR)
+            .map(function() {
+                return parseInt($(this).attr('id').replace('timer-', ''), 10);
+            })
+            .get()
+            .filter(Number.isFinite)
+            .sort((a, b) => a - b);
+    }
+
+    function syncActiveTimers() {
+        const timersContainer = $(ACTIVE_TIMERS_SELECTOR);
+        if (timersContainer.length === 0) {
+            return;
+        }
+
+        $.getJSON('/api/list_active_sessions/')
+            .done(function(sessions) {
+                const serverIds = sessions
+                    .filter(session => session.is_active)
+                    .map(session => session.id)
+                    .sort((a, b) => a - b);
+                const localIds = getLocalTimerIds();
+                const hasChanges = serverIds.length !== localIds.length || serverIds.some((id, idx) => id !== localIds[idx]);
+
+                if (hasChanges) {
+                    window.location.reload();
+                }
+            });
+    }
+
     // Update durations every second
     setInterval(updateDurations, 1000);
+    // Poll server state so timers stopped/started outside the web UI show up quickly.
+    setInterval(syncActiveTimers, 5000);
 
     // Initial update
     updateDurations();
+    syncActiveTimers();
 });


### PR DESCRIPTION
### Motivation
- Timers started/stopped outside the web UI (e.g. via the CLI/API) were not reflected promptly on the timers page or the home timers section, requiring manual refreshes.
- The previous JS updated every `.card` on the page which touched unrelated elements and performed unnecessary DOM work.

### Description
- Limit duration updates to timer cards inside `#active-timers` by changing the selector to `#active-timers .card[id^="timer-"]` in `core/static/core/js/dynamic_timers.js` to avoid touching unrelated cards.
- Add a polling sync loop in `core/static/core/js/dynamic_timers.js` that calls `/api/list_active_sessions/` every 5 seconds and compares server-side active session IDs with locally rendered timer IDs, triggering `window.location.reload()` when they differ so CLI/API changes appear quickly.
- Add helper `getLocalTimerIds()` and `syncActiveTimers()` in the same JS file to support the above comparison and run an initial sync on page load.
- Update `list_active_sessions` in `core/api.py` to apply `filter_by_active_context(...)` so the polled API mirrors the UI's active-context filtering and avoids false positives when comparing IDs.

### Testing
- Ran `python manage.py check` which failed in this environment because required environment variables are not set (`SECRET_KEY`), so the project-level Django system checks could not complete; no other automated tests were executed in this session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dcd6e12e848325a7c25e9a2c82ffcf)