### PR TITLE
Improve active-timers syncing and add home-specific timer script

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -1548,6 +1548,9 @@ def list_sessions(request):
 @permission_classes([IsAuthenticated])
 def list_active_sessions(request):
     sessions = Sessions.objects.filter(is_active=True, user=request.user)
+    sessions = filter_by_active_context(
+        sessions, request, override_context_id=request.query_params.get("context")
+    )
     serializer = SessionSerializer(sessions, many=True)
     return Response(serializer.data)
 

--- a/core/static/core/js/home_timers.js
+++ b/core/static/core/js/home_timers.js
@@ -1,6 +1,7 @@
 $(document).ready(function() {
     const ACTIVE_TIMERS_SELECTOR = '#active-timers';
     const TIMER_CARD_SELECTOR = `${ACTIVE_TIMERS_SELECTOR} .card[id^="timer-"]`;
+    const SYNC_INTERVAL_MS = 5000;
 
     function updateDurations() {
         $(TIMER_CARD_SELECTOR).each(function() {
@@ -20,24 +21,21 @@ $(document).ready(function() {
         let minutes = Math.floor(remainingSecondsAfterHours / 60);
         let seconds = remainingSecondsAfterHours % 60;
         let days = Math.floor(hours / 24);
-        hours = hours % 24; // Remaining hours after days
+        hours = hours % 24;
 
-        let build_time = '';
-
-
+        let buildTime = '';
         if (days > 0) {
-             build_time += days + ' day' + (days !== 1 ? 's ' : ' ');
+            buildTime += days + ' day' + (days !== 1 ? 's ' : ' ');
         }
         if (hours > 0) {
-           build_time += hours + ' hour' + (hours !== 1 ? 's ' : ' ');
+            buildTime += hours + ' hour' + (hours !== 1 ? 's ' : ' ');
         }
         if (minutes > 0) {
-            build_time += minutes + ' minute' + (minutes !== 1 ? 's ' : ' ') ;
+            buildTime += minutes + ' minute' + (minutes !== 1 ? 's ' : ' ');
         }
 
-        build_time += seconds + ' second' + (seconds !== 1 ? 's' : '');
-
-        return build_time;
+        buildTime += seconds + ' second' + (seconds !== 1 ? 's' : '');
+        return buildTime;
     }
 
     function getLocalTimerIds() {
@@ -48,6 +46,21 @@ $(document).ready(function() {
             .get()
             .filter(Number.isFinite)
             .sort((a, b) => a - b);
+    }
+
+    let refreshInFlight = false;
+
+    function refreshTimerSection() {
+        if (refreshInFlight) {
+            return;
+        }
+        refreshInFlight = true;
+
+        const refreshUrl = `${window.location.pathname} #active-timers > *`;
+        $(ACTIVE_TIMERS_SELECTOR).load(refreshUrl, function() {
+            refreshInFlight = false;
+            updateDurations();
+        });
     }
 
     function syncActiveTimers() {
@@ -65,36 +78,19 @@ $(document).ready(function() {
                 const localIds = getLocalTimerIds();
                 const serverSet = new Set(serverIds);
                 const allLocalTimersStillActive = localIds.every(id => serverSet.has(id));
-                const isPartialList = timersContainer.data('partial-list') === true;
                 const maxVisible = parseInt(timersContainer.data('max-visible'), 10);
-                const isAtCapacity = isPartialList && Number.isFinite(maxVisible) && localIds.length >= maxVisible;
+                const hasCapacity = Number.isFinite(maxVisible) ? localIds.length < maxVisible : true;
+                const canShowNewTimers = hasCapacity && serverIds.length !== localIds.length;
 
-                let hasChanges = !allLocalTimersStillActive;
-                if (!hasChanges) {
-                    // Full timer pages should always mirror the server list exactly.
-                    // Partial timer lists (dashboard) only need to refresh on additions
-                    // when there is available room.
-                    if (isPartialList) {
-                        if (!isAtCapacity && serverIds.length !== localIds.length) {
-                            hasChanges = true;
-                        }
-                    } else if (serverIds.length !== localIds.length) {
-                        hasChanges = true;
-                    }
-                }
-
-                if (hasChanges) {
-                    window.location.reload();
+                if (!allLocalTimersStillActive || canShowNewTimers) {
+                    refreshTimerSection();
                 }
             });
     }
 
-    // Update durations every second
     setInterval(updateDurations, 1000);
-    // Poll server state so timers stopped/started outside the web UI show up quickly.
-    setInterval(syncActiveTimers, 5000);
+    setInterval(syncActiveTimers, SYNC_INTERVAL_MS);
 
-    // Initial update
     updateDurations();
     syncActiveTimers();
 });

--- a/core/templates/core/home.html
+++ b/core/templates/core/home.html
@@ -3,7 +3,7 @@
 {% load time_formats %}
 
 {% block head_includes %}
-    <script src="{% static 'core/js/dynamic_timers.js' %}?v={{ static_version.dynamic_timers }}" type="text/javascript"></script>
+    <script src="{% static 'core/js/home_timers.js' %}?v={{ static_version.home_timers }}" type="text/javascript"></script>
 {% endblock %}
 
 {% block content %}
@@ -12,7 +12,7 @@
             <u>Active Timers</u>
         </a>
     </h2>
-    <div id="active-timers">
+    <div id="active-timers" data-max-visible="5">
         {% for timer in timers %}
             <div class="card" id="timer-{{ timer.id }}" data-start-time="{{ timer.start_time|date:"Y-m-d H:i:s" }}">
                 <table class="timer-row">


### PR DESCRIPTION
### Motivation
- Ensure the active-timers UI remains consistent with server state and supports pages that show partial/limited timer lists.
- Reduce unnecessary DOM traversal and improve time formatting to include days/hours for long-running timers.
- Provide a specialized, lightweight client-side refresh for the home page that can reload only the timers fragment when needed.

### Description
- Apply `filter_by_active_context` to `list_active_sessions` in `core/api.py` so the active-sessions API respects the same context filtering as other session endpoints.
- Update `core/static/core/js/dynamic_timers.js` to scope DOM queries to `#active-timers .card[id^="timer-"]`, add `formatTime` that includes days/hours, implement `getLocalTimerIds` and `syncActiveTimers` which polls `/api/list_active_sessions/` and reloads the page when the server-side active timers differ from the client.
- Add a new `core/static/core/js/home_timers.js` that mirrors the duration updates but is home-page aware: it checks capacity via `data-max-visible`, refreshes the timers fragment via `$(selector).load()` when needed, and guards concurrent refreshes with `refreshInFlight`.
- Update `core/templates/core/home.html` to load `home_timers.js` instead of `dynamic_timers.js` and add `data-max-visible="5"` to `#active-timers` for partial-list behavior.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dcd6e12e848325a7c25e9a2c82ffcf)