### PR TITLE
Improve stop/edit session date-time and note authoring UX

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -193,8 +193,60 @@ class UpdateSessionForm(forms.ModelForm):
         model = Sessions
         fields = ['start_time', 'end_time', 'note']
         widgets = {
+            'start_time': forms.DateTimeInput(
+                attrs={'type': 'datetime-local', 'class': 'half-width'},
+                format='%Y-%m-%dT%H:%M',
+            ),
+            'end_time': forms.DateTimeInput(
+                attrs={'type': 'datetime-local', 'class': 'half-width'},
+                format='%Y-%m-%dT%H:%M',
+            ),
             'note': forms.Textarea(attrs={'placeholder': 'Note', 'class': 'half-width', 'required': False}),
         }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields['start_time'].input_formats = ['%Y-%m-%dT%H:%M', '%Y-%m-%d %H:%M:%S']
+        self.fields['end_time'].input_formats = ['%Y-%m-%dT%H:%M', '%Y-%m-%d %H:%M:%S']
+
+    def clean(self):
+        cleaned_data = super().clean()
+        start_time = cleaned_data.get('start_time')
+        end_time = cleaned_data.get('end_time')
+
+        if start_time and end_time and end_time < start_time:
+            self.add_error('end_time', "End time cannot be earlier than start time.")
+
+        return cleaned_data
+
+
+class StopTimerForm(forms.ModelForm):
+    class Meta:
+        model = Sessions
+        fields = ['start_time', 'end_time', 'note']
+        widgets = {
+            'start_time': forms.DateTimeInput(
+                attrs={'type': 'datetime-local', 'class': 'half-width'},
+                format='%Y-%m-%dT%H:%M',
+            ),
+            'end_time': forms.DateTimeInput(
+                attrs={'type': 'datetime-local', 'class': 'half-width'},
+                format='%Y-%m-%dT%H:%M',
+            ),
+            'note': forms.Textarea(
+                attrs={
+                    'placeholder': 'Session Note...',
+                    'class': 'half-width',
+                    'rows': 4,
+                    'required': False,
+                }
+            ),
+        }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields['start_time'].input_formats = ['%Y-%m-%dT%H:%M', '%Y-%m-%d %H:%M:%S']
+        self.fields['end_time'].input_formats = ['%Y-%m-%dT%H:%M', '%Y-%m-%d %H:%M:%S']
 
     def clean(self):
         cleaned_data = super().clean()

--- a/core/static/core/js/session_note_editor.js
+++ b/core/static/core/js/session_note_editor.js
@@ -1,0 +1,122 @@
+(function () {
+    function wrapSelection(textarea, before, after) {
+        const start = textarea.selectionStart || 0;
+        const end = textarea.selectionEnd || 0;
+        const selected = textarea.value.slice(start, end);
+        const wrapped = `${before}${selected}${after}`;
+
+        textarea.setRangeText(wrapped, start, end, 'end');
+        textarea.focus();
+    }
+
+    function insertLink(textarea) {
+        const start = textarea.selectionStart || 0;
+        const end = textarea.selectionEnd || 0;
+        const selected = textarea.value.slice(start, end) || 'link text';
+        const url = window.prompt('Enter URL', 'https://');
+
+        if (!url) {
+            return;
+        }
+
+        const markdownLink = `[${selected}](${url})`;
+        textarea.setRangeText(markdownLink, start, end, 'end');
+        textarea.focus();
+    }
+
+    function setupDictation(editorContainer, textarea) {
+        const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+        const dictateButton = editorContainer.querySelector('[data-note-action="dictate"]');
+        const status = editorContainer.querySelector('[data-note-status]');
+
+        if (!dictateButton || !status) {
+            return;
+        }
+
+        if (!SpeechRecognition) {
+            dictateButton.disabled = true;
+            status.textContent = 'Dictation unavailable in this browser.';
+            return;
+        }
+
+        const recognition = new SpeechRecognition();
+        recognition.continuous = true;
+        recognition.interimResults = false;
+        recognition.lang = document.documentElement.lang || 'en-US';
+
+        let listening = false;
+
+        dictateButton.addEventListener('click', function () {
+            if (listening) {
+                recognition.stop();
+                return;
+            }
+            recognition.start();
+        });
+
+        recognition.onstart = function () {
+            listening = true;
+            dictateButton.textContent = 'Stop dictation';
+            status.textContent = 'Listening...';
+        };
+
+        recognition.onend = function () {
+            listening = false;
+            dictateButton.textContent = 'Dictate';
+            status.textContent = 'Dictation stopped.';
+        };
+
+        recognition.onerror = function () {
+            status.textContent = 'Dictation error. Please try again.';
+        };
+
+        recognition.onresult = function (event) {
+            const result = event.results[event.results.length - 1];
+            if (!result || !result[0]) {
+                return;
+            }
+
+            const transcript = result[0].transcript.trim();
+            if (!transcript) {
+                return;
+            }
+
+            const prefix = textarea.value.trim().length > 0 ? ' ' : '';
+            textarea.value = `${textarea.value}${prefix}${transcript}`;
+            status.textContent = 'Added dictated text.';
+        };
+    }
+
+    function initializeNoteEditor(editorContainer) {
+        const textarea = editorContainer.querySelector('textarea');
+        if (!textarea) {
+            return;
+        }
+
+        editorContainer.querySelectorAll('[data-note-action]').forEach(function (button) {
+            const action = button.getAttribute('data-note-action');
+
+            if (action === 'dictate') {
+                return;
+            }
+
+            button.addEventListener('click', function (event) {
+                event.preventDefault();
+
+                if (action === 'bold') {
+                    wrapSelection(textarea, '**', '**');
+                } else if (action === 'italic') {
+                    wrapSelection(textarea, '*', '*');
+                } else if (action === 'link') {
+                    insertLink(textarea);
+                }
+            });
+        });
+
+        setupDictation(editorContainer, textarea);
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+        document.querySelectorAll('[data-note-editor]').forEach(initializeNoteEditor);
+    });
+})();

--- a/core/templates/core/stop_timer.html
+++ b/core/templates/core/stop_timer.html
@@ -4,6 +4,7 @@
 
 {% block head_includes %}
     <script src="{% static 'core/js/dynamic_timers.js' %}?v={{ static_version.dynamic_timers }}" type="text/javascript"></script>
+    <script src="{% static 'core/js/session_note_editor.js' %}?v={{ static_version.session_note_editor }}" type="text/javascript"></script>
 {% endblock %}
 
 {% block content %}
@@ -30,8 +31,33 @@
             </table>
         </div>
 
-        <textarea class="card" id="session_note" name="session_note" rows="4" cols="50"
-                  placeholder="Session Note...">{% if timer.note %}{{ timer.note }}{% endif %}</textarea>
+        <section id="input-fields" class="card stacked">
+            <div id="date-fields" class="flex-row">
+                <span class="label-input">
+                    {{ form.start_time.label_tag }}
+                    {{ form.start_time }}
+                    {{ form.start_time.errors }}
+                </span>
+                <span class="label-input">
+                    {{ form.end_time.label_tag }}
+                    {{ form.end_time }}
+                    {{ form.end_time.errors }}
+                </span>
+            </div>
+
+            <div class="label-input" data-note-editor>
+                <label for="{{ form.note.id_for_label }}">Session Note</label>
+                <div class="flex-row">
+                    <button type="button" class="secondary-button" data-note-action="bold"><b>B</b></button>
+                    <button type="button" class="secondary-button" data-note-action="italic"><i>I</i></button>
+                    <button type="button" class="secondary-button" data-note-action="link"><i class="fa fa-link"></i></button>
+                    <button type="button" class="secondary-button" data-note-action="dictate">Dictate</button>
+                </div>
+                <small data-note-status></small>
+                {{ form.note }}
+                {{ form.note.errors }}
+            </div>
+        </section>
 
         <div class="button-row">
             <button type="button" class="timer-button" onclick="window.location.href='{% url 'timers' %}'">

--- a/core/templates/core/update_session.html
+++ b/core/templates/core/update_session.html
@@ -6,6 +6,7 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js" type="text/javascript"> </script>
     <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.16/jquery-ui.min.js" type="text/javascript"></script>
     <script src="{% static 'core/js/timer_search_projects.js' %}?v={{ static_version.timer_search_projects }}" type="text/javascript"></script>
+    <script src="{% static 'core/js/session_note_editor.js' %}?v={{ static_version.session_note_editor }}" type="text/javascript"></script>
 {% endblock %}
 
 {% block content %}
@@ -36,8 +37,15 @@
            </div>
 
             <!--edit session notes-->
-            <span class="label-input">
+            <span class="label-input" data-note-editor>
                 {{ form.note.label_tag }}
+                <div class="flex-row">
+                    <button type="button" class="secondary-button" data-note-action="bold"><b>B</b></button>
+                    <button type="button" class="secondary-button" data-note-action="italic"><i>I</i></button>
+                    <button type="button" class="secondary-button" data-note-action="link"><i class="fa fa-link"></i></button>
+                    <button type="button" class="secondary-button" data-note-action="dictate">Dictate</button>
+                </div>
+                <small data-note-status></small>
                 {{ form.note }}
                 {{ form.note.errors }}
             </span>

--- a/core/views.py
+++ b/core/views.py
@@ -515,20 +515,27 @@ def update_session(request, session_id: int):
 
 @login_required
 def stop_timer(request, session_id: int):
-    timer = Sessions.objects.get(id=session_id)
+    timer = get_object_or_404(Sessions, id=session_id, user=request.user)
 
     if request.method == "POST":
-        timer.is_active = False
-        timer.end_time = timezone.now()
+        form = StopTimerForm(request.POST, instance=timer)
+        if form.is_valid():
+            timer = form.save(commit=False)
+            timer.is_active = False
+            timer.save()
+            messages.success(request, "Stopped timer")
+            return redirect("timers")
 
-        if "session_note" in request.POST:
-            timer.note = request.POST["session_note"]
+        messages.error(request, "Please correct the errors below.")
+    else:
+        form = StopTimerForm(
+            instance=timer,
+            initial={
+                "end_time": timezone.now(),
+            },
+        )
 
-        timer.save()
-        messages.success(request, "Stopped timer")
-        return redirect("timers")
-
-    context = {"title": "Stop Timer", "timer": timer}
+    context = {"title": "Stop Timer", "timer": timer, "form": form}
 
     return render(request, "core/stop_timer.html", context)
 


### PR DESCRIPTION
### Motivation
- Make editing and stopping sessions easier by using native date+time inputs instead of free-form text and providing a lightweight authoring experience for session notes. 
- Allow users to dictate notes to avoid repetitive manual typing and add basic markdown helpers (bold, italic, links) to speed up note entry.

### Description
- Replaced free-text start/end fields in the session edit form with `datetime-local` widgets and added server-side `input_formats` and the existing end-before-start validation in `UpdateSessionForm` (`core/forms.py`).
- Added a new `StopTimerForm` (in `core/forms.py`) and updated `stop_timer` to use `get_object_or_404(..., user=request.user)` and the form for POST handling so the stop-timer page supports editable start/end timestamps and note edits (`core/views.py`).
- Added a small client-side note editor `core/static/core/js/session_note_editor.js` that provides bold/italic/link markdown helpers and optional browser Speech Recognition dictation with graceful fallback.
- Wired the editor and controls into the templates for stop and edit flows by updating `core/templates/core/stop_timer.html` and `core/templates/core/update_session.html` to include the toolbar and load the new script.

### Testing
- Ran `python manage.py check` to validate Django configuration, but it failed because the environment is missing `SECRET_KEY` so Django settings could not initialize (no other automated tests were run in this environment).
- Templates and server code were exercised locally in this environment only to ensure imports and syntax are valid (no runtime server start due to missing settings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e79999724c8325907dbafc43bbd193)