### PR TITLE
Enable tilde (~) strikethrough in markdown rendering

### DIFF
--- a/core/templatetags/markdown_render.py
+++ b/core/templatetags/markdown_render.py
@@ -9,4 +9,7 @@ register = template.Library()
 @register.filter()
 @stringfilter
 def markdown(value):
-    return md.markdown(value, extensions=['markdown.extensions.fenced_code'])
+    return md.markdown(
+        value,
+        extensions=['markdown.extensions.fenced_code', 'pymdownx.tilde'],
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ Pillow
 concurrent-log-handler
 apscheduler
 markdown
+pymdown-extensions
 inflect
 django-environ
 google-genai


### PR DESCRIPTION
### Motivation
- Allow users to write strikethrough using tildes (e.g. `~~text~~`) in rendered markdown across the app by enabling the appropriate markdown extension.

### Description
- Updated the Django template filter `core/templatetags/markdown_render.py` to pass the `pymdownx.tilde` extension to `markdown.markdown` alongside the existing `markdown.extensions.fenced_code` extension.
- Added `pymdown-extensions` to `requirements.txt` so the `pymdownx.tilde` extension is available at runtime.

### Testing
- Ran `python -m py_compile core/templatetags/markdown_render.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f31b67a2b08333b0e9d87864d6f428)