### PR TITLE
Normalize single-tilde strikethrough and enable pymdownx.tilde

### DIFF
--- a/core/templatetags/markdown_render.py
+++ b/core/templatetags/markdown_render.py
@@ -1,3 +1,5 @@
+import re
+
 from django import template
 from django.template.defaultfilters import stringfilter
 
@@ -5,8 +7,15 @@ import markdown as md
 
 register = template.Library()
 
+SINGLE_TILDE_STRIKE_PATTERN = re.compile(r'(?<!~)~([^~\n]+?)~(?!~)')
+
 
 @register.filter()
 @stringfilter
 def markdown(value):
-    return md.markdown(value, extensions=['markdown.extensions.fenced_code'])
+    normalized_value = SINGLE_TILDE_STRIKE_PATTERN.sub(r'~~\1~~', value)
+
+    return md.markdown(
+        normalized_value,
+        extensions=['markdown.extensions.fenced_code', 'pymdownx.tilde'],
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ Pillow
 concurrent-log-handler
 apscheduler
 markdown
+pymdown-extensions
 inflect
 django-environ
 google-genai


### PR DESCRIPTION
### Motivation
- Allow single-tilde strike-through like `~text~` in template Markdown rendering by normalizing it to double-tilde and enabling the corresponding pymdown extension.

### Description
- Add `SINGLE_TILDE_STRIKE_PATTERN` regex and normalization in `core/templatetags/markdown_render.py`, import `re`, include `pymdownx.tilde` in the Markdown `extensions` list, and add `pymdown-extensions` to `requirements.txt`.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f31b67a2b08333b0e9d87864d6f428)